### PR TITLE
add View Categories functionality

### DIFF
--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -47,7 +47,7 @@ namespace TabloidMVC.Controllers
         public ActionResult Create(Category category)
         {
             List<Category> categories = _categoryRepository.GetAll();
-            if (categories.Any(c => c.Name == category.Name && c.isDeleted == true))
+            if (categories.Any(c => c.Name == category.Name))
             {
                 ModelState.AddModelError("", "Category already exists.");
                 return View(category);

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TabloidMVC.Repositories;
+using TabloidMVC.Models;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+
+namespace TabloidMVC.Controllers
+{
+    public class CategoryController : Controller
+    {
+        private readonly ICategoryRepository _catRepo;
+
+        //dependency injection
+        public CategoryController(ICategoryRepository categoryRepository)
+        {
+            _catRepo = categoryRepository;
+        }
+
+        // GET: CategoryController
+        public ActionResult Index()
+        {
+            List<Category> categories = _catRepo.GetAll();
+            return View(categories);
+        }
+
+        // GET: CategoryController/Details/5
+        public ActionResult Details(int id)
+        {
+            return View();
+        }
+
+        // GET: CategoryController/Create
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: CategoryController/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: CategoryController/Edit/5
+        public ActionResult Edit(int id)
+        {
+            return View();
+        }
+
+        // POST: CategoryController/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Edit(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: CategoryController/Delete/5
+        public ActionResult Delete(int id)
+        {
+            return View();
+        }
+
+        // POST: CategoryController/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+    }
+}

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -70,6 +70,7 @@ namespace TabloidMVC.Controllers
         // GET: CategoryController/Edit/5
         public ActionResult Edit(int id)
         {
+            Category category = _catRepo.
             return View();
         }
 

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -9,6 +9,7 @@ using TabloidMVC.Models;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 
+
 namespace TabloidMVC.Controllers
 {
     public class CategoryController : Controller
@@ -34,7 +35,7 @@ namespace TabloidMVC.Controllers
             return View();
         }
 
-        // GET: CategoryController/Create
+        // GET: Category/Create
         public ActionResult Create()
         {
             return View();
@@ -43,15 +44,26 @@ namespace TabloidMVC.Controllers
         // POST: CategoryController/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Create(IFormCollection collection)
+        public ActionResult Create(Category category)
         {
-            try
+            List<Category> categories = _catRepo.GetAll();
+            if (categories.Any(c => c.Name == category.Name))
             {
-                return RedirectToAction(nameof(Index));
+                ModelState.AddModelError("", "Category already exists.");
+                return View(category);
             }
-            catch
+            else
             {
-                return View();
+                try
+                {
+                    _catRepo.AddCategory(category);
+
+                    return RedirectToAction("Index");
+                }
+                catch (Exception ex)
+                {
+                    return View(category);
+                }
             }
         }
 

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -14,18 +14,18 @@ namespace TabloidMVC.Controllers
 {
     public class CategoryController : Controller
     {
-        private readonly ICategoryRepository _catRepo;
+        private readonly ICategoryRepository _categoryRepository;
 
         //dependency injection
         public CategoryController(ICategoryRepository categoryRepository)
         {
-            _catRepo = categoryRepository;
+            _categoryRepository = categoryRepository;
         }
 
         // GET: CategoryController
         public ActionResult Index()
         {
-            List<Category> categories = _catRepo.GetAll();
+            List<Category> categories = _categoryRepository.GetAll();
             return View(categories);
         }
 
@@ -46,8 +46,8 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Create(Category category)
         {
-            List<Category> categories = _catRepo.GetAll();
-            if (categories.Any(c => c.Name == category.Name))
+            List<Category> categories = _categoryRepository.GetAll();
+            if (categories.Any(c => c.Name == category.Name && c.isDeleted == true))
             {
                 ModelState.AddModelError("", "Category already exists.");
                 return View(category);
@@ -56,7 +56,7 @@ namespace TabloidMVC.Controllers
             {
                 try
                 {
-                    _catRepo.AddCategory(category);
+                    _categoryRepository.AddCategory(category);
 
                     return RedirectToAction("Index");
                 }
@@ -70,43 +70,44 @@ namespace TabloidMVC.Controllers
         // GET: CategoryController/Edit/5
         public ActionResult Edit(int id)
         {
-            Category category = _catRepo.
-            return View();
+            Category category = _categoryRepository.GetCategoryById(id);
+            if (category == null)
+            {
+                return NotFound();
+            }
+            return View(category);
         }
 
         // POST: CategoryController/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(int id, IFormCollection collection)
+        public ActionResult Edit(int id, Category category)
         {
             try
             {
-                return RedirectToAction(nameof(Index));
+                _categoryRepository.UpdateCategory(category);
+                return RedirectToAction("Index");
             }
-            catch
+            catch (Exception ex)
             {
-                return View();
+                return View(category);
             }
         }
 
-        // GET: CategoryController/Delete/5
-        public ActionResult Delete(int id)
-        {
-            return View();
-        }
+
 
         // POST: CategoryController/Delete/5
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public ActionResult Delete(int id, IFormCollection collection)
+       
+        public ActionResult Delete(Category category)
         {
             try
             {
-                return RedirectToAction(nameof(Index));
+                _categoryRepository.DeleteCategory(category);
+                return RedirectToAction("Index");
             }
-            catch
+            catch (Exception ex)
             {
-                return View();
+                return View(category);
             }
         }
     }

--- a/TabloidMVC/Models/Category.cs
+++ b/TabloidMVC/Models/Category.cs
@@ -1,8 +1,11 @@
-﻿namespace TabloidMVC.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TabloidMVC.Models
 {
     public class Category
     {
         public int Id { get; set; }
+        [Required]
         public string Name { get; set; }
     }
 }

--- a/TabloidMVC/Models/Category.cs
+++ b/TabloidMVC/Models/Category.cs
@@ -7,5 +7,6 @@ namespace TabloidMVC.Models
         public int Id { get; set; }
         [Required]
         public string Name { get; set; }
+        public bool isDeleted { get; set; }
     }
 }

--- a/TabloidMVC/Models/Category.cs
+++ b/TabloidMVC/Models/Category.cs
@@ -7,6 +7,6 @@ namespace TabloidMVC.Models
         public int Id { get; set; }
         [Required]
         public string Name { get; set; }
-        public bool isDeleted { get; set; }
+        public int isDeleted { get; set; }
     }
 }

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -18,6 +18,7 @@ namespace TabloidMVC.Repositories
                 {
                     cmd.CommandText = @"SELECT id, name
                         FROM Category
+                        WHERE IsDeleted = 0
                         ORDER BY name
                         ";
                     var reader = cmd.ExecuteReader();
@@ -84,12 +85,13 @@ namespace TabloidMVC.Repositories
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                    INSERT INTO Category([Name])
+                    INSERT INTO Category([Name], IsDeleted)
                     OUTPUT INSERTED.ID
-                    VALUES ( @name );
+                    VALUES ( @name, @IsDeleted );
                     ";
 
                     cmd.Parameters.AddWithValue("@name", category.Name);
+                    cmd.Parameters.AddWithValue("@IsDeleted", 0);
 
                     category.Id = (int)cmd.ExecuteScalar();
 
@@ -126,7 +128,8 @@ namespace TabloidMVC.Repositories
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                        DELETE from Category
+                        Update Category
+                        SET [IsDeleted] = 1
                         WHERE Id = @id
                         ";
                     cmd.Parameters.AddWithValue("@id", category.Id);

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -39,25 +39,39 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
-    
+
         public Category GetCategoryById(int id)
         {
-            using(SqlConnection conn = Connection)
+            using (SqlConnection conn = Connection)
             {
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"";
+                    cmd.CommandText = @"
+                        SELECT Id, Name
+                        FROM Category
+                        WHERE Id = @id
+                        ";
 
 
                     cmd.Parameters.AddWithValue("@id", id);
                     Category category = null;
-                    using(SqlDataReader reader = cmd.ExecuteReader())
+                    using (SqlDataReader reader = cmd.ExecuteReader())
                     {
                         while (reader.Read())
-                        { }
+                        {
+                            if (category == null)
+                            {
+                                category = new Category
+                                {
+                                    Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                    Name = reader.GetString(reader.GetOrdinal("Name"))
+                                };
+                            }
+
+                        }
                     }
-                return category;
+                    return category;
                 }
             }
         }
@@ -82,13 +96,13 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
-    
+
         public void UpdateCategory(Category category)
         {
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
-                using(SqlCommand cmd = conn.CreateCommand())
+                using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
                         Update Category
@@ -104,23 +118,23 @@ namespace TabloidMVC.Repositories
             }
         }
 
-        public void DeleteCategory(int categoryId)
+        public void DeleteCategory(Category category)
         {
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
-                using(SqlCommand cmd = conn.CreateCommand())
+                using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
                         DELETE from Category
                         WHERE Id = @id
                         ";
-                    cmd.Parameters.AddWithValue("@id", categoryId);
+                    cmd.Parameters.AddWithValue("@id", category.Id);
 
                     cmd.ExecuteNonQuery();
-                }    
+                }
             }
         }
-    
+
     }
 }

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using TabloidMVC.Models;
+using Microsoft.Data.SqlClient;
+
 
 namespace TabloidMVC.Repositories
 {
@@ -37,5 +39,29 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+    
+        public void AddCategory(Category category)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                    INSERT INTO Category([Name])
+                    OUTPUT INSERTED.ID
+                    VALUES ( @name );
+                    ";
+
+                    cmd.Parameters.AddWithValue("@name", category.Name);
+
+                    category.Id = (int)cmd.ExecuteScalar();
+
+                }
+            }
+        }
+    
+    
+    
     }
 }

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -14,7 +14,10 @@ namespace TabloidMVC.Repositories
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "SELECT id, name FROM Category";
+                    cmd.CommandText = @"SELECT id, name
+                        FROM Category
+                        ORDER BY name
+                        ";
                     var reader = cmd.ExecuteReader();
 
                     var categories = new List<Category>();

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -40,6 +40,28 @@ namespace TabloidMVC.Repositories
             }
         }
     
+        public Category GetCategoryById(int id)
+        {
+            using(SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"";
+
+
+                    cmd.Parameters.AddWithValue("@id", id);
+                    Category category = null;
+                    using(SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        { }
+                    }
+                return category;
+                }
+            }
+        }
+
         public void AddCategory(Category category)
         {
             using (SqlConnection conn = Connection)
@@ -61,7 +83,44 @@ namespace TabloidMVC.Repositories
             }
         }
     
-    
+        public void UpdateCategory(Category category)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using(SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        Update Category
+                        SET
+                            [Name] = @name
+                        WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@name", category.Name);
+                    cmd.Parameters.AddWithValue("@id", category.Id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public void DeleteCategory(int categoryId)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using(SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE from Category
+                        WHERE Id = @id
+                        ";
+                    cmd.Parameters.AddWithValue("@id", categoryId);
+
+                    cmd.ExecuteNonQuery();
+                }    
+            }
+        }
     
     }
 }

--- a/TabloidMVC/Repositories/ICategoryRepository.cs
+++ b/TabloidMVC/Repositories/ICategoryRepository.cs
@@ -6,5 +6,7 @@ namespace TabloidMVC.Repositories
     public interface ICategoryRepository
     {
         List<Category> GetAll();
+
+        void AddCategory(Category category);
     }
 }

--- a/TabloidMVC/Repositories/ICategoryRepository.cs
+++ b/TabloidMVC/Repositories/ICategoryRepository.cs
@@ -7,6 +7,11 @@ namespace TabloidMVC.Repositories
     {
         List<Category> GetAll();
 
+        Category GetCategoryById();
         void AddCategory(Category category);
+
+        void UpdateCategory(Category category);
+
+        void DeleteCategory(int categoryId);
     }
 }

--- a/TabloidMVC/Repositories/ICategoryRepository.cs
+++ b/TabloidMVC/Repositories/ICategoryRepository.cs
@@ -7,11 +7,11 @@ namespace TabloidMVC.Repositories
     {
         List<Category> GetAll();
 
-        Category GetCategoryById();
+        Category GetCategoryById(int id);
         void AddCategory(Category category);
 
         void UpdateCategory(Category category);
 
-        void DeleteCategory(int categoryId);
+        void DeleteCategory(Category category);
     }
 }

--- a/TabloidMVC/Views/Category/Create.cshtml
+++ b/TabloidMVC/Views/Category/Create.cshtml
@@ -1,0 +1,34 @@
+﻿@model TabloidMVC.Models.Category
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>Category</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/TabloidMVC/Views/Category/Edit.cshtml
+++ b/TabloidMVC/Views/Category/Edit.cshtml
@@ -1,0 +1,38 @@
+﻿@model TabloidMVC.Models.Category
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>Category</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+               
+                <input asp-for="Id" class="form-control"type="hidden" />
+               
+            </div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/TabloidMVC/Views/Category/Index.cshtml
+++ b/TabloidMVC/Views/Category/Index.cshtml
@@ -31,9 +31,16 @@
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
             <td>
-                @Html.ActionLink("Edit", "Edit", new { id=item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id=item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id=item.Id })
+                <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                    <i class="fas fa-pencil-alt"></i>
+                </a>
+                <a asp-action="Delete" asp-route-id="@item.Id"
+                   class="btn btn-outline-primary mx-1" title="Delete" onclick="return confirm(`Are you sure you want to delete this category?`);">
+                    <i class="fas fa-trash"></i>
+                </a>
+                @*@Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
+                @Html.ActionLink("Details", "Details", new { id = item.Id }) |
+                @Html.ActionLink("Delete", "Delete", new { id = item.Id })*@
             </td>
         </tr>
 }

--- a/TabloidMVC/Views/Category/Index.cshtml
+++ b/TabloidMVC/Views/Category/Index.cshtml
@@ -1,0 +1,41 @@
+﻿@model IEnumerable<TabloidMVC.Models.Category>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h1>Index</h1>
+
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            @*<th>
+                @Html.DisplayNameFor(model => model.Id)
+            </th>*@
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            @*<td>
+                @Html.DisplayFor(modelItem => item.Id)
+            </td>*@
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.ActionLink("Edit", "Edit", new { id=item.Id }) |
+                @Html.ActionLink("Details", "Details", new { id=item.Id }) |
+                @Html.ActionLink("Delete", "Delete", new { id=item.Id })
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -30,6 +30,11 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
+                         
+                            <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
+                            </li>
+                            
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -34,12 +34,12 @@
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="MyIndex">MY POSTS</a>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">
-<<<<<<< HEAD
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
-=======
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tag" asp-action="Index">TAG MANAGEMENT</a>
->>>>>>> c6193186d8f545ec7966dfb2b9d23999760a312b
                             </li>
+                            <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
+                            </li>
+
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -30,13 +30,11 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
-                         
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
-                            </li>
-                            
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="MyIndex">MY POSTS</a>
+                            </li>
+                            <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORY MANAGEMENT</a>
                             </li>
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>


### PR DESCRIPTION
Added functionality to view categories, add categories, edit categories, and delete categories.

**functionality is for admin users, but not yet restricted to admin users (in future issue tickets).

git fetch --all
git checkout hcr-viewCategories

rerun the initial sql scripts - update table creation table in the Category section as follows:
```CREATE TABLE [Category] (
  [Id] integer PRIMARY KEY IDENTITY,
  [Name] nvarchar(50) NOT NULL,
  [IsDeleted] integer NOT NULL
)
```

rerun the seed sql script and update the Category section as follows:
```SET IDENTITY_INSERT [Category] ON
INSERT INTO [Category] ([Id], [Name], [IsDeleted]) 
VALUES (1, 'Technology', 0), (2, 'Close Magic', 0), (3, 'Politics', 0), (4, 'Science', 0), (5, 'Improv', 0), 
	   (6, 'Cthulhu Sightings', 0), (7, 'History', 0), (8, 'Home and Garden', 0), (9, 'Entertainment', 0), 
	   (10, 'Cooking', 0), (11, 'Music', 0), (12, 'Movies', 0), (13, 'Regrets', 0);
SET IDENTITY_INSERT [Category] OFF
```

run TabloidMVC and click "Category Management" in the nav bar to see a list of categories sorted a-z. 
Click the "create category" affordance to create new category.
Click the pencil affordance to edit a category.
Click the trash can affordance to delete a category.
